### PR TITLE
fix/tests: ensure teardown of playmode tests

### DIFF
--- a/game/Assets/Tests/PlayMode/GameSuite.cs
+++ b/game/Assets/Tests/PlayMode/GameSuite.cs
@@ -15,13 +15,11 @@ namespace Tests.PlayMode
     public class GameSuite : InputTestFixture
     {
 
-        private Keyboard _keyboard;
-        private Mouse _mouse;
-
+        [SetUp]
         public override void Setup()
         {
-            SceneManager.LoadScene("Scenes/Game");
-            _keyboard = InputSystem.AddDevice<Keyboard>();
+            SceneManager.LoadScene("Scenes/Game", LoadSceneMode.Single);
+            base.Setup();
         }
 
         [UnityTest]
@@ -33,20 +31,26 @@ namespace Tests.PlayMode
             yield return null;
         }
 
-    //     [UnityTest]
-    //     public IEnumerator TestInteraction()
-    //     {
-    //         GameObject player = GameObject.Find("TmpCharacter");
-    //
-    //         GameObject interactionCube = GameObject.Find("Interaction Cube");
-    //         Vector3 cubePosition = interactionCube.transform.position;
-    //         cubePosition.z -= 1;
-    //
-    //         player.transform.position = cubePosition;
-    //         PressAndRelease(_keyboard.eKey);
-    //         InputSystem.Update();
-    //         yield return new WaitForEndOfFrame();
-    //         // TODO: test quiz canvas
-    //     }
+        //     [UnityTest]
+        //     public IEnumerator TestInteraction()
+        //     {
+        //         GameObject player = GameObject.Find("TmpCharacter");
+        //
+        //         GameObject interactionCube = GameObject.Find("Interaction Cube");
+        //         Vector3 cubePosition = interactionCube.transform.position;
+        //         cubePosition.z -= 1;
+        //
+        //         player.transform.position = cubePosition;
+        //         PressAndRelease(_keyboard.eKey);
+        //         InputSystem.Update();
+        //         yield return new WaitForEndOfFrame();
+        //         // TODO: test quiz canvas
+        //     }
+
+        [TearDown]
+        public override void TearDown()
+        {
+            base.TearDown();
+        }
     }
 }

--- a/game/Assets/Tests/PlayMode/MenuSuite.cs
+++ b/game/Assets/Tests/PlayMode/MenuSuite.cs
@@ -14,10 +14,11 @@ namespace Tests.PlayMode
     {
         private Mouse _mouse;
 
+        [SetUp]
         public override void Setup()
         {
+            SceneManager.LoadScene("Scenes/Menu", LoadSceneMode.Single);
             base.Setup();
-            SceneManager.LoadScene("Scenes/Menu");
             _mouse = InputSystem.AddDevice<Mouse>();
         }
 
@@ -43,6 +44,12 @@ namespace Tests.PlayMode
 
             sceneName = SceneManager.GetActiveScene().name;
             Assert.That(sceneName, Is.EqualTo("Offline"));
+        }
+
+        [TearDown]
+        public override void TearDown()
+        {
+            base.TearDown();
         }
     }
 }

--- a/game/Assets/Tests/PlayMode/OfflineSuite.cs
+++ b/game/Assets/Tests/PlayMode/OfflineSuite.cs
@@ -11,10 +11,11 @@ namespace Tests.PlayMode
     {
         private Mouse _mouse;
 
+        [SetUp]
         public override void Setup()
         {
+            SceneManager.LoadScene("Scenes/Offline", LoadSceneMode.Single);
             base.Setup();
-            SceneManager.LoadScene("Scenes/Offline");
             _mouse = InputSystem.AddDevice<Mouse>();
         }
 
@@ -39,6 +40,12 @@ namespace Tests.PlayMode
 
             sceneName = SceneManager.GetActiveScene().name;
             Assert.That(sceneName, Is.EqualTo("Menu"));
+        }
+
+        [TearDown]
+        public override void TearDown()
+        {
+            base.TearDown();
         }
     }
 }

--- a/game/Assets/Tests/PlayMode/RoomSuite.cs
+++ b/game/Assets/Tests/PlayMode/RoomSuite.cs
@@ -11,10 +11,11 @@ namespace Tests.PlayMode
     {
         private Mouse _mouse;
 
+        [SetUp]
         public override void Setup()
         {
+            SceneManager.LoadScene("Scenes/Room", LoadSceneMode.Single);
             base.Setup();
-            SceneManager.LoadScene("Scenes/Room");
             _mouse = InputSystem.AddDevice<Mouse>();
         }
 
@@ -39,6 +40,12 @@ namespace Tests.PlayMode
 
             sceneName = SceneManager.GetActiveScene().name;
             Assert.That(sceneName, Is.EqualTo("Offline"));
+        }
+
+        [TearDown]
+        public override void TearDown()
+        {
+            base.TearDown();
         }
     }
 }


### PR DESCRIPTION
**Description**
Playmode tests are failing since the teardown method isn't being used from the base class

**Linked issue(s)**
N/A

**Type of change**

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (non-breaking change which updates documentation)

**Checklist**

- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] New and existing unit tests pass locally with my changes
